### PR TITLE
Updated for TF v0.13

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,13 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.13"
 
   required_providers {
-    local = "~> 1.2"
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 1.2"
+    }
+    aws = {
+      source = "hashicorp/aws"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.12"
 
   required_providers {
     local = {


### PR DESCRIPTION
To not execute the "terraform 0.13upgrade -yes" command during TF v0.13 upgrade