### PR TITLE
Add support for graviton instance, default to t4g.nano

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -8,7 +8,7 @@ data "aws_ami" "this" {
 
   filter {
     name   = "name"
-    values = ["al2023-ami-2023*-*-x86_64"]
+    values = ["al2023-ami-2023*-*-${local.instance_arch}"]
   }
 
   filter {

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  instance_arch = contains([
+    "t4g",
+    "m6g",
+    "c6g",
+    "r6g"
+  ], substr(var.instance_type, 0, 3)) ? "arm64" : "x86_64"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 resource "aws_security_group" "this" {
   count  = var.manage_security_group ? 1 : 0
   vpc_id = var.vpc_id
+  name = "${var.env}-${var.name}"
 
   ingress {
     protocol    = "tcp"

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "this" {
   count  = var.manage_security_group ? 1 : 0
   vpc_id = var.vpc_id
-  name = "${var.env}-${var.name}"
+  name   = "${var.env}-${var.name}"
 
   ingress {
     protocol    = "tcp"

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable "ec2_key_pair_name" {
 variable "instance_type" {
   type        = string
   description = "EC2 instance type for bastion host"
-  default     = "t3.nano"
+  default     = "t4g.nano"
 }
 
 variable "instance_ami" {

--- a/variables.tf
+++ b/variables.tf
@@ -37,9 +37,9 @@ variable "instance_type" {
 }
 
 variable "instance_ami" {
-  type = string
+  type        = string
   description = "AMI ID override for the bastion host. Keep in mind, this module config is targeting Amazon Linux 2023)"
-  default = ""
+  default     = ""
 }
 
 variable "security_groups" {


### PR DESCRIPTION
# What's in this PR
- Added support for graviton instance, default to t4g.nano
- Add name to security group
- Format