### PR TITLE
CORE-863 Local provider removed/Readme updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,12 @@ module "bastion" {
 }
 ```
 
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | ~> 1.2 |
 
 ## Providers
 
@@ -126,20 +126,21 @@ No modules.
 
 ## Inputs
 
-| Name                                                                                            | Description | Type | Default | Required |
-|-------------------------------------------------------------------------------------------------|-------------|------|---------|:--------:|
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
 | <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | List of network subnets that are allowed. According to PCI-DSS, CIS AWS and SOC2 providing a default wide-open CIDR is not secure. | `list(string)` | n/a | yes |
-| <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile)                           | n/a | `any` | n/a | yes |
-| <a name="input_ec2_key_pair_name"></a> [ec2\_key\_pair\_name](#input\_ec2\_key\_pair\_name)     | n/a | `any` | n/a | yes |
-| <a name="input_env"></a> [env](#input\_env)                                                     | n/a | `any` | n/a | yes |
+| <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | AWS Profile to use during tunnel creation | `string` | n/a | yes |
+| <a name="input_ec2_key_pair_name"></a> [ec2\_key\_pair\_name](#input\_ec2\_key\_pair\_name) | EC2 Key Pair Name | `string` | n/a | yes |
+| <a name="input_env"></a> [env](#input\_env) | Environment name, for example `dev` | `string` | n/a | yes |
 | <a name="input_ext_security_groups"></a> [ext\_security\_groups](#input\_ext\_security\_groups) | External security groups to add to bastion host | `list(any)` | `[]` | no |
-| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type)                     | n/a | `string` | `"t3.nano"` | no |
-| <a name="input_name"></a> [name](#input\_name)                                                  | n/a | `string` | `"bastion"` | no |
-| <a name="input_public_subnets"></a> [public\_subnets](#input\_private\_subnets)                 | n/a | `any` | n/a | yes |
-| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets)               | n/a | `any` | n/a | yes |
-| <a name="input_ssh_forward_rules"></a> [ssh\_forward\_rules](#input\_ssh\_forward\_rules)       | Rules that will enable port forwarding. SSH Config syntax | `list(string)` | `[]` | no |
-| <a name="input_ssm_role"></a> [ssm\_role](#input\_ssm\_role)                                    | n/a | `string` | `"arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"` | no |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id)                                          | n/a | `any` | n/a | yes |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 instance type for bastion host | `string` | `"t3.nano"` | no |
+| <a name="input_name"></a> [name](#input\_name) | n/a | `string` | `"bastion"` | no |
+| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | Private subnets | `list(string)` | n/a | yes |
+| <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | Public subnets (if set, private subnets are ignored) | `list(string)` | `[]` | no |
+| <a name="input_ssh_forward_rules"></a> [ssh\_forward\_rules](#input\_ssh\_forward\_rules) | Rules that will enable port forwarding. SSH Config syntax | `list(string)` | `[]` | no |
+| <a name="input_ssm_role"></a> [ssm\_role](#input\_ssm\_role) | n/a | `string` | `"arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags for the resources | `map(string)` | `{}` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID | `string` | n/a | yes |
 
 ## Outputs
 
@@ -149,3 +150,4 @@ No modules.
 | <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | n/a |
 | <a name="output_security_group"></a> [security\_group](#output\_security\_group) | n/a |
 | <a name="output_ssh_config"></a> [ssh\_config](#output\_ssh\_config) | n/a |
+<!-- END_TF_DOCS -->

--- a/versions.tf
+++ b/versions.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    local = {
-      source  = "hashicorp/local"
-      version = "~> 1.2"
-    }
     aws = {
       source = "hashicorp/aws"
     }


### PR DESCRIPTION
#### What's new:

- Provider `local` removed
- No changes detected

#### Testing done:
Deploy succesful:
<img width="700" alt="Screenshot 2025-03-26 at 23 43 45" src="https://github.com/user-attachments/assets/746c153b-25e7-43fe-8728-8d5cbb83625a" />

Update found no changes:
<img width="892" alt="Screenshot 2025-03-27 at 00 13 21" src="https://github.com/user-attachments/assets/8c88ff7b-bb0d-4390-99fc-94df658b4f29" />
